### PR TITLE
Add queryParam for getProjects()

### DIFF
--- a/src/main/java/com/messners/gitlab/api/ProjectApi.java
+++ b/src/main/java/com/messners/gitlab/api/ProjectApi.java
@@ -31,7 +31,7 @@ public class ProjectApi extends AbstractApi {
      * @throws GitLabApiException
      */
     public List<Project> getProjects() throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "projects");
+        Response response = get(Response.Status.OK, UriComponent.decodeQuery("per_page=9999", true), "projects");
         return (response.readEntity(new GenericType<List<Project>>() {
         }));
     }


### PR DESCRIPTION
Hello,

We should do the same as getAllProjects() to retrieve all projects at once.

Julien